### PR TITLE
:zap: lighter render on some parts of the website

### DIFF
--- a/src/components/HomeHero/index.js
+++ b/src/components/HomeHero/index.js
@@ -17,11 +17,11 @@ const Wrapper = styled.article`
 	position: relative;
 	overflow: hidden;
 	z-index: 3;
-	margin-bottom: 6rem;
+	margin-bottom: 2rem;
 	min-height: 24rem;
 	${above.md`
 		min-height: 32rem;
-		margin-bottom: 8rem;
+		margin-bottom: 4rem;
 	`};
 `
 

--- a/src/components/PostCard/Tag.js
+++ b/src/components/PostCard/Tag.js
@@ -20,6 +20,7 @@ const Wrapper = styled(Link)`
 	padding: 0.5rem 0.75rem;
 	position: relative;
 	z-index: 2;
+	transition: opacity 0.3s, transform 0.5s;
 	${above.md`
 		opacity: 0;
 		transform: translateX(2rem);
@@ -27,8 +28,6 @@ const Wrapper = styled(Link)`
 	`} .PostCard:hover &, .PostCard:focus & {
 		opacity: 1;
 		transform: none;
-		transition: opacity 0.3s ${p => `${p.index * 0.06}s`},
-			transform 0.5s ${p => `${p.index * 0.06}s`};
 	}
 	&:hover {
 		background: white;
@@ -37,7 +36,10 @@ const Wrapper = styled(Link)`
 `
 
 const Tag = ({tag, index}) => (
-	<Wrapper index={index} to={`/tags/${kebabCase(tag)}/`}>
+	<Wrapper
+		to={`/tags/${kebabCase(tag)}/`}
+		style={{transitionDelay: `${index * 0.06}s`}}
+	>
 		{tag}
 	</Wrapper>
 )

--- a/src/components/PostCard/index.js
+++ b/src/components/PostCard/index.js
@@ -43,8 +43,22 @@ export const Wrapper = styled.article.attrs({className: 'PostCard'})`
 	${above.xg`
 		flex-direction: ${p => (p.reverse ? 'row' : 'row-reverse')};
 	`};
+	&:before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		box-shadow: 0 1.5rem 4rem -0.75rem rgba(0,0,0,0.3);
+		opacity: 0;
+		transition: all .6s cubic-bezier(0.165, 0.84, 0.44, 1);
+	}
 	&:hover, &:focus, &:active{
 		z-index: 1;
+		&:before {
+			opacity: 1;
+		}
 	}
 `
 

--- a/src/components/PostCard/index.js
+++ b/src/components/PostCard/index.js
@@ -26,68 +26,26 @@ const StyledCardCell = styled(CardCell)`
 `
 
 export const Wrapper = styled.article.attrs({className: 'PostCard'})`
-	transition: padding ${timing}, margin ${timing}, box-shadow ${timing};
-	z-index: 0;
-	width: 100%;
 	flex: 1;
 	position: relative;
 	margin-bottom: 0.5rem;
-	${above.md`
-		margin-bottom: 0;
-		&:hover, &:focus, &:active{
-			box-shadow: 0 37.125px 70px -12.125px rgba(0,0,0,0.3);
-			z-index: 1;
-		}
-	`};
-`
-
-const Padding = styled.div`
-	padding: 6px 6px;
-	min-height: 100%;
-	display: flex;
-	flex-direction: column;
-`
-
-const PlainDiv = ({className, children, style}) => (
-	<div className={className} style={style}>
-		{children}
-	</div>
-)
-
-const Inset = styled(PlainDiv)`
-	background: ${p =>
-		!p.dark ? 'white' : p.alt ? 'rgba(255,255,255,0.03)' : colors.base};
+	background: ${p => !p.dark ? 'white' : p.alt ? 'rgba(255,255,255,0.03)' : colors.base};
 	color: ${p => (p.dark ? 'white' : colors.base)};
-	border-bottom: 1px solid ${p => (p.dark ? colors.base88 : colors.base11)};
-	position: relative;
-	overflow: hidden;
-	transition: padding ${timing}, margin ${timing}, box-shadow ${timing};
-	flex: 1;
-	${above.md`
-		border-bottom: 0;
-		${Wrapper}:hover &, ${Wrapper}:focus &, ${Wrapper}:active &{
-			padding: 6px;
-			margin: -6px;
-		}
-	`} ${above.xg`
-		display: flex;
-	`};
-`
-
-const PostContent = styled.div`
-	width: 100%;
-	height: 100%;
-	position: relative;
+	margin: 0.375rem;
 	${above.md`
 		display: flex;
 		align-items: stretch;
 		min-height: ${p => (p.compact ? 'auto' : minHeight)};
 		flex-direction: ${p =>
 			p.size ? (p.reverse ? 'row' : 'row-reverse') : 'column'};
+		};
 	`};
 	${above.xg`
 		flex-direction: ${p => (p.reverse ? 'row' : 'row-reverse')};
 	`};
+	&:hover, &:focus, &:active{
+		z-index: 1;
+	}
 `
 
 const ImageWrapper = styled.div`
@@ -95,7 +53,7 @@ const ImageWrapper = styled.div`
 	align-items: center;
 	justify-content: center;
 	object-fit: cover;
-	margin: -6px;
+	overflow: hidden;
 	position: relative;
 	flex: 0;
 	min-height: 14rem;
@@ -158,12 +116,6 @@ const Anchor = styled(Link)`
 	left: 0;
 	right: 0;
 	bottom: 0;
-	outline-offset: -6px;
-	transition: outline ${timing};
-	${Wrapper}:hover &,
-	${Wrapper}:active & {
-		outline-offset: 0;
-	}
 `
 
 const Title = styled.div`
@@ -187,13 +139,13 @@ const Editorial = styled(({url, color, title, style, ...props}) => (
 ))`
 	text-decoration: none;
 	position: relative;
-	z-index: 3;
+	z-index: 1;
 	color: currentColor;
 	display: block;
 `
 
 const Author = styled(AuthorCard)`
-	z-index: 3;
+	z-index: 1;
 	padding-top: 0.25rem;
 	margin-top: auto;
 	${above.md &&
@@ -246,35 +198,35 @@ const PostCard = ({
 		md={size ? 12 : 6}
 		mini={dynamic && !(cover && cover)}
 	>
-		<Wrapper>
-			<Padding>
-				<Inset dark={dark} alt={alt}>
-					<PostContent reverse={reverse} size={size} compact={compact}>
-						{cover && (
-							<ImageWrapper size={size} compact={compact}>
-								<Image image={cover} dark={dark} />
-								{tags && (
-									<TagsWrapper>
-										{tags.map((tag, index) => (
-											<Tag key={tag} tag={tag} index={index} />
-										))}
-									</TagsWrapper>
-								)}
-							</ImageWrapper>
-						)}
-						<Text size={size}>
-							<Meta>
-								{editorial && <Editorial {...editorial} />}
-								{date && <PostDate>{format.postDate(date)}</PostDate>}
-							</Meta>
-							{title && <Title>{title}</Title>}
-							{authors && authors.map(author => (
-								<Author key={author.url} size='small' {...author} dark={dark} />
+		<Wrapper
+			dark={dark}
+			alt={alt}
+			reverse={reverse}
+			size={size}
+			compact={compact}
+		>
+			{cover && (
+				<ImageWrapper size={size} compact={compact}>
+					<Image image={cover} dark={dark} />
+					{tags && (
+						<TagsWrapper>
+							{tags.map((tag, index) => (
+								<Tag key={tag} tag={tag} index={index} />
 							))}
-						</Text>
-					</PostContent>
-				</Inset>
-			</Padding>
+						</TagsWrapper>
+					)}
+				</ImageWrapper>
+			)}
+			<Text size={size}>
+				<Meta>
+					{editorial && <Editorial {...editorial} />}
+					{date && <PostDate>{format.postDate(date)}</PostDate>}
+				</Meta>
+				{title && <Title>{title}</Title>}
+				{authors && authors.map(author => (
+					<Author key={author.url} size='small' {...author} dark={dark} />
+				))}
+			</Text>
 			<Anchor to={url} />
 		</Wrapper>
 	</StyledCardCell>

--- a/src/components/TitleBar/index.js
+++ b/src/components/TitleBar/index.js
@@ -9,13 +9,8 @@ const Wrapper = styled.div`
 	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: baseline;
-	position: relative;
-	position: sticky;
-	top: 3.5rem;
-	z-index: 2;
 	background: ${colors.base03};
 	color: ${colors.base88};
-	box-shadow: -6rem 0 0 ${colors.base03}, 6rem 0 0 ${colors.base03};
 	${p =>
 		p.dark &&
 		`
@@ -23,7 +18,6 @@ const Wrapper = styled.div`
 		color: ${colors.white};
 		box-shadow: -6rem 0 0 ${colors.base}, 6rem 0 0 ${colors.base};
 	`} ${above.md`
-		top: 4rem;
 		margin-bottom: 1rem;
 	`};
 `
@@ -57,11 +51,11 @@ const Anchor = styled(Link)`
 	`};
 `
 
-const FixedTitle = ({title, label, url, dark, style}) => (
+const TitleBar = ({title, label, url, dark, style}) => (
 	<Wrapper dark={dark} style={style}>
 		<Title>{title}</Title>
 		{url && <Anchor to={url}>{label}</Anchor>}
 	</Wrapper>
 )
 
-export default FixedTitle
+export default TitleBar

--- a/src/indexes/articles.js
+++ b/src/indexes/articles.js
@@ -15,7 +15,7 @@ import Container from '../components/Container'
 import {Row, Cell} from '../components/Grid'
 import {CardRow} from '../components/CardGrid'
 import Navbar from '../components/Navbar'
-import FixedTitle from '../components/FixedTitle'
+import TitleBar from '../components/TitleBar'
 import PostCard from '../components/PostCard'
 import Editorials from '../components/Editorials'
 import ScrollList from '../components/ScrollList'
@@ -87,7 +87,7 @@ const PageComponent = ({posts, tags, authors, editorials, currentDate}) => (
 					<ScrollList title="Tags" url="/tags" list={tags.map(enhanceTag)} />
 				</section>
 				<section>
-					<FixedTitle dark title="Todas as publicações" />
+					<TitleBar dark title="Todas as publicações" />
 						{Object.entries(groupByDate(currentDate)(posts)).map(([distance, posts]) => (
 							<div style={{position: 'relative'}} key={distance}>
 								<DateMarker>

--- a/src/indexes/articles.js
+++ b/src/indexes/articles.js
@@ -77,7 +77,7 @@ const PageComponent = ({posts, tags, authors, editorials, currentDate}) => (
 		<Navbar style={{position: 'fixed', top: 0, zIndex: 3}} dark={true} />
 		<main style={{padding: '8rem 0'}}>
 			<Container>
-				<section style={{marginBottom: '6rem'}}>
+				<section style={{marginBottom: '4rem'}}>
 					<Editorials editorials={editorials} style={{marginBottom: '2rem'}} />
 					<ScrollList
 						title="Repórteres"

--- a/src/indexes/authors.js
+++ b/src/indexes/authors.js
@@ -9,7 +9,7 @@ import Container from '../components/Container'
 import {Row, Cell} from '../components/Grid'
 import Navbar from '../components/Navbar'
 import Hero from '../components/Hero'
-import FixedTitle from '../components/FixedTitle'
+import TitleBar from '../components/TitleBar'
 import AuthorCard from '../components/AuthorCard'
 
 const getAllSemesters = flow([
@@ -27,7 +27,7 @@ const AuthorsPage = ({authors}) => (
 			<section style={{padding: '6rem 0 4rem'}}>
 				{getAllSemesters(authors).map((semester, index) => (
 					<Fragment key={semester}>
-						<FixedTitle
+						<TitleBar
 							title={!index ? `Semestre atual (${semester})` : semester}
 							label={!index && 'Expediente'}
 							url={!index && '/reporteres'}

--- a/src/indexes/authors.js
+++ b/src/indexes/authors.js
@@ -24,7 +24,7 @@ const AuthorsPage = ({authors}) => (
 		<Hero title="Repórteres" sub={`${authors.length} repórteres no total`} />
 		<Container>
 			<MetaTags title="Repórteres" />
-			<section style={{padding: '6rem 0 4rem'}}>
+			<section style={{padding: '6rem 0 2rem'}}>
 				{getAllSemesters(authors).map((semester, index) => (
 					<Fragment key={semester}>
 						<TitleBar

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,15 +1,53 @@
 import {graphql} from 'gatsby'
 import React, {Fragment} from 'react'
+import styled from 'styled-components'
 import {mapProps, compose} from 'recompose'
 import flattenBlogPostInfo from '../fragments/BlogPostInfo'
+import {colors} from '../constants'
 import {withLayout} from '../components/Layout'
 import MetaTags from '../components/MetaTags'
 import Container from '../components/Container'
+import Link from '../components/StylableLink'
 import {CardRow} from '../components/CardGrid'
 import Navbar from '../components/Navbar'
 import TitleBar from '../components/TitleBar'
 import HomeHero from '../components/HomeHero'
 import PostCard from '../components/PostCard'
+
+const Button = styled(Link)`
+	display: flex;
+	align-items: center;
+	position: relative;
+	justify-content: space-between;
+	padding: 1.75rem 2rem;
+	background: ${colors.white};
+	color: ${colors.base};
+	font-weight: 600;
+	text-decoration: none;
+	color: ${colors.base88};
+	&:after {
+		content: '→';
+		font-size: 2em;
+		font-weight: 300;
+	}
+	&:before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		box-shadow: 0 0.75rem 2rem -0.375rem rgba(0,0,0,0.1);
+		opacity: 0;
+		transition: all .6s cubic-bezier(0.165, 0.84, 0.44, 1);
+	}
+	&:hover, &:focus, &:active{
+		z-index: 1;
+		&:before {
+			opacity: 1;
+		}
+	}
+`
 
 const PageComponent = ({posts: [hero, ...posts]}) => (
 	<Fragment>
@@ -34,6 +72,7 @@ const PageComponent = ({posts: [hero, ...posts]}) => (
 						/>
 					))}
 				</CardRow>
+				<Button to='/materias'>Ver todas as matérias</Button>
 			</Container>
 		</main>
 	</Fragment>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,7 @@ import MetaTags from '../components/MetaTags'
 import Container from '../components/Container'
 import {CardRow} from '../components/CardGrid'
 import Navbar from '../components/Navbar'
-import FixedTitle from '../components/FixedTitle'
+import TitleBar from '../components/TitleBar'
 import HomeHero from '../components/HomeHero'
 import PostCard from '../components/PostCard'
 
@@ -18,7 +18,7 @@ const PageComponent = ({posts: [hero, ...posts]}) => (
 		<main style={{paddingBottom: '8rem'}}>
 			{hero && <HomeHero {...hero} />}
 			<Container>
-				<FixedTitle
+				<TitleBar
 					title="Publicações recentes"
 					label="Ver todas"
 					url="/materias"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,6 +55,7 @@ export const pageQuery = graphql`
 		blog: allMarkdownRemark(
 			sort: {order: DESC, fields: [frontmatter___date]}
 			filter: {fields: {template: {eq: "article"}}}
+			limit: 16
 		) {
 			# [TODO]: separate hero
 			# [TODO]: fetch CoverImage for hero, CoverThumbnail for the rest


### PR DESCRIPTION
this PR lightens the render of several parts of the site:
- [x] simpler `<PostCard/>` (without overlay/cropping animation)
- [x] [silky performance box-shadow animation](https://tobiasahlin.com/blog/how-to-animate-box-shadow/) on `<PostCard/>`
- [x] limit the posts rendered on the homepage (by 16)
- [x] remove the sticky behaviour in some `<TitleBars/>`

![giphy-13](https://user-images.githubusercontent.com/5063967/64869963-d1448a80-d618-11e9-8246-b754392ec53b.gif)
